### PR TITLE
add access control allow origin header to categories API

### DIFF
--- a/server/src/routes/api/categories.ts
+++ b/server/src/routes/api/categories.ts
@@ -8,7 +8,8 @@ export async function get(_req, res) {
   } catch (e) {
     console.error(e);
     res.writeHead(500, {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
     });
 
     return res.end(


### PR DESCRIPTION
Allows all domains to make requests to the categories api by adding:
`"Access-Control-Allow-Origin": "*"`
to the header.